### PR TITLE
Fixed correct type in doc for Response

### DIFF
--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -32,7 +32,7 @@ class Response
     }
 
     /**
-     * @return string
+     * @return array
      */
     public function getBody()
     {


### PR DESCRIPTION
It returns an array, not a string